### PR TITLE
include: netns: convert net_hash_mix() to unsigned int

### DIFF
--- a/include/net/netns/hash.h
+++ b/include/net/netns/hash.h
@@ -3,7 +3,7 @@
 
 #include <net/net_namespace.h>
 
-static inline u32 net_hash_mix(const struct net *net)
+static inline unsigned int net_hash_mix(struct net *net)
 {
 	return net->hash_mix;
 }


### PR DESCRIPTION
* Matching to google common to avoid conflict merge in future
* References:
  39815fcf685a263660e9278dba2a1257730a718d netns: constify net_hash_mix() and various callers
  c2bca92ba948f3def1f99f6b429ec39e07354dc2 netns: provide pure entropy for net_hash_mix()